### PR TITLE
feat: add walk page for route playback

### DIFF
--- a/pages/walk.vue
+++ b/pages/walk.vue
@@ -1,0 +1,21 @@
+<template>
+  <div>
+    <p v-if="!id">Missing or malformed id</p>
+    <p v-else-if="error">Failed to load route</p>
+    <MapView v-else-if="data" :route-data="data" />
+    <p v-else>Loading...</p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import MapView from '~/components/MapView.vue'
+
+const route = useRoute()
+const idParam = route.query.id
+const id = typeof idParam === 'string' ? idParam : null
+
+const { data, error } = await useFetch<GeoJSON.GeoJSON>(() =>
+  id ? `/routes/${id}.geojson` : null
+)
+</script>
+


### PR DESCRIPTION
## Summary
- add walk page that loads GeoJSON route by query id and displays MapView
- allow MapView to accept external route data

## Testing
- `pnpm build` *(fails: Nuxt Content requires better-sqlite3; broken pnpm-lock)*

------
https://chatgpt.com/codex/tasks/task_e_68aacf9565c48327ab579cc36c0a94f8